### PR TITLE
Add Addressfinder to the membership page

### DIFF
--- a/app/assets/javascripts/addressfinder.js.erb
+++ b/app/assets/javascripts/addressfinder.js.erb
@@ -1,0 +1,57 @@
+(function () {
+  var widget = null;
+
+  // Binds a new Addressfinder widget to any textarea element with a class named 'addressfinder'
+  function initialiseAddressfinder() {
+    var elements = document.querySelectorAll('textarea.addressfinder')
+
+    // IE compatibility enabled
+    Array.prototype.forEach.call(elements, function (addressElement) {
+      widget = new AddressFinder.Widget(
+        addressElement,
+        '<%= Rails.configuration.x.addressfinder.public_key %>',
+        'NZ',
+        {
+          address_params: {
+            post_box: '0'
+          }
+        }
+      );
+
+      // When an address is selected, put each portion of the address on a new
+      // line. This matches existing behaviour. 
+      widget.on('result:select', function (fullAddress, metaData) {
+        var addressLines = fullAddress.split(', ');
+
+        addressElement.value = addressLines.join(', \n');
+        addressElement.rows = addressLines.length;
+      });
+
+      // Make the number of rows in the textarea element just the right
+      // size for the current address (if any).
+      var initialLineCount = addressElement.value.split(',').length;
+      addressElement.rows = initialLineCount;
+    });
+  }
+
+  // Downloads the Addressfinder widget, and calls the initialisation
+  // function when loaded. This avoids Addressfinder from blocking any
+  // other actions or assets that may need to be loaded. 
+  function downloadAddressfinderWidget(initialisationFunction) {
+    var script = document.createElement('script');
+    script.src = 'https://api.addressfinder.io/assets/v3/widget.js';
+    script.async = true;
+    script.onload = initialisationFunction;
+    document.body.appendChild(script);
+  };
+
+  // Only activate Addressfinder if there are elements with an 'addressfinder'
+  // class present. Otherwise, do nothing. 
+  document.addEventListener('DOMContentLoaded', function () {
+    var addressFields = document.getElementsByClassName('addressfinder');
+
+    if (addressFields.length > 0) {
+      downloadAddressfinderWidget(initialiseAddressfinder);
+    }
+  });
+})();

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for(member) do |f| %>
   <%= f.input :full_name %>
   <%= f.input :email %>
-  <%= f.input :address, as: :text, input_html: { rows: 3 } %>
+  <%= f.input :address, as: :text, input_html: { rows: 3, class: "addressfinder" } %>
   <%= f.button :submit %>
 <% end %>
 

--- a/config/initializers/addressfinder.rb
+++ b/config/initializers/addressfinder.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Note: the public_key is not a secet token, as it may be visible to the end user
+  config.x.addressfinder.public_key = 'PKWQ7XJH3GBUCLFMV49Y'
+end


### PR DESCRIPTION
Hi @danielfone 

Here is the PR as [promised](https://github.com/rubynz/membership-register/issues/1) that enables Addressfinder on the membership page. I have tested on the following platforms:

- Safari (MacOS and iOS)
- Chrome
- Firefox
- Internet Explorer 11
- Edge

The typical usage scenario for Addressfinder is attaching to an `input` element, rather than a `textarea`. It does work with a textarea, but can feel a little odd with the completions appearing below a taller element. 

I have attempted to improve this by sizing the `textarea` to match the number of lines in the address. I think it works well, but would appreciate your feedback on this. 

Please let me know if you need any other changes? 

Cheers

Nigel