### PR TITLE
Voting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@
 
 config/database.yml
 db/schema.rb
-.rspec
 docker-compose.yml
 
 /public/packs
@@ -27,5 +26,10 @@ docker-compose.yml
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
-.env
 public/assets
+
+# Ignore RSpec persistence file
+.rspec-status
+
+# Ignore local environment variable configuration
+.env

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,9 @@ gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.0'
 
 group :development, :test do
-  gem "rspec-rails"
+  gem 'rspec-rails'
+  gem 'capybara'
+  gem 'capybara-email'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 5.0'
 
 group :development, :test do
+  # Load local .env files
+  gem 'dotenv-rails'
+
   gem 'rspec-rails'
   gem 'capybara'
   gem 'capybara-email'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,10 @@ GEM
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     ffi (1.15.3)
     globalid (0.4.2)
@@ -208,6 +212,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   capybara
   capybara-email
+  dotenv-rails
   listen
   pg
   puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-email (3.0.2)
+      capybara (>= 2.4, < 4.0)
+      mail
     concurrent-ruby (1.1.9)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -204,6 +207,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.4)
   capybara
+  capybara-email
   listen
   pg
   puma

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ To start a local server, run:
 
 By default, this will start a local webserver on [http://localhost:3000](http://localhost:3000)
 
+
+## Testing
+
+This codebase started out without tests. Some are being introduced over time.
+
+To run tests:
+
+    bundle exec rspec
+
+## Voting
+
+Voting can be enabled by setting a `VOTE_URL_TEMPLATE` environment variable.
+
+    VOTE_URL_TEMPLATE=https://voting-site.com/token=%token%
+
+When set, a message will appear on the home page, and members will be able to get a unique link emailed to them through a form, which substitutes `%token%` in the URL template with each member's unique `voting_token`.
+
 ## Maintenance
 
 ### Upgrading Rails

--- a/app/controllers/vote_requests_controller.rb
+++ b/app/controllers/vote_requests_controller.rb
@@ -1,0 +1,25 @@
+class VoteRequestsController < ApplicationController
+  before_action :verify_voting_enabled
+
+  def new
+  end
+
+  def create
+    member = Member.find_by(email: params.require(:email))
+
+    if member
+      MembershipMailer.vote_request(member).deliver_now
+    else
+      # Simulate a small delay to prevent membership disclosure via timing
+      # attacks.
+      sleep rand(0.1..0.3)
+    end
+  end
+
+  private
+
+  def verify_voting_enabled
+    return if helpers.voting_enabled?
+    raise 'Voting not enabled'
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,8 @@ module ApplicationHelper
     content_tag(:span, time_ago_in_words(time), title: time)
   end
 
+  def voting_enabled?
+    Rails.configuration.vote_url_template.present?
+  end
+
 end

--- a/app/mailers/membership_mailer.rb
+++ b/app/mailers/membership_mailer.rb
@@ -10,4 +10,10 @@ class MembershipMailer < ApplicationMailer
     @member = member
     mail to: @member.email
   end
+
+  def vote_request(member)
+    @member = member
+    @vote_url = Rails.configuration.vote_url_template.sub('%token%', @member.voting_token)
+    mail to: @member.email
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -10,6 +10,8 @@ class Member < ApplicationRecord
     updated_at
   ]
 
+  has_secure_token :voting_token
+
   before_create :set_joined_at
   after_create :reset_token!
 

--- a/app/views/application/home.en.html.erb
+++ b/app/views/application/home.en.html.erb
@@ -1,4 +1,14 @@
 <div class="row">
+  <% if voting_enabled? %>
+    <div class="col-md-12">
+      <h2>Voting now live</h2>
+      <p>
+        Voting for this year's AGM is available for members.
+        <%= link_to 'Cast your vote…', new_vote_request_path %>
+      </p>
+    </div>
+  <% end %>
+
   <div class="col-md-6">
     <div class="page-header">
       <h2>New Members</h2>
@@ -21,6 +31,5 @@
       Already a member and need to update your details? Not sure if you're a member?<br>
       <%= link_to 'Check existing membership…', new_membership_inquiry_path %>
     </p>
-
   </div>
 </div>

--- a/app/views/membership_mailer/vote_request.html.erb
+++ b/app/views/membership_mailer/vote_request.html.erb
@@ -1,0 +1,20 @@
+<style type="text/css">
+  body { background: #eee; }
+</style>
+<style type="text/css">
+    @media only screen and (max-width: 1000px){
+        .bodyContent{font-size:14pt !important;}
+    }
+</style>
+
+<div class="content" style="width: 25em;background: white;margin: 1em auto;padding: 1em;font-size: 12pt;font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;">
+  <h2>
+    Cast your Ruby New Zealand vote
+  </h2>
+
+  <p>Your unique voting link is:</p>
+
+  <p><%= link_to @vote_url, @vote_url %></p>
+
+  <p>Please don't share this URL with anyone.</p>
+</div>

--- a/app/views/vote_requests/create.html.erb
+++ b/app/views/vote_requests/create.html.erb
@@ -1,0 +1,8 @@
+<h2>Thanks!</h2>
+
+<p>If you have a membership, you should shortly receive a unique voting link to your email address.</p>
+
+<p>Allow a few minutes for the email to arrive.</p>
+
+<p>Please keep this link secret.</p>
+

--- a/app/views/vote_requests/new.html.erb
+++ b/app/views/vote_requests/new.html.erb
@@ -1,0 +1,13 @@
+<h2>Cast your vote</h2>
+
+<p>Enter your registered email address to receive your unique voting link:</p>
+
+<%= form_with url: vote_requests_url, method: :post do |f| %>
+  <div class="form-group email required">
+    <%= f.label :email, class: 'control-label' %>
+    <%= f.email_field :email, class: 'form-control' %>
+    <p>Double-check your email address. To protect member privacy, we won't tell you if it's valid.</p>
+  </div>
+
+  <%= f.submit 'Send voting link', class: 'btn btn-default' %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,9 @@ module MembershipRegister
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Used for membership voting
+    config.vote_url_template = ENV['VOTE_URL_TEMPLATE']
+
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,4 +53,10 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Used for voting
+  config.vote_url_template = 'https://example.com/vote/%token%'
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,8 @@ en:
   membership_mailer:
     inquiry:
       subject: "Membership Details"
+    vote_request:
+      subject: "Your voting link"
 
   simple_form:
     hints:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,10 @@ Rails.application.routes.draw do
 
   resources :members, except: :index
   resource :membership_inquiry, only: [:new, :create, :show]
+  resources :vote_requests, only: [:new, :create]
 
   namespace :admin do
     resources :members
   end
+
 end

--- a/db/migrate/20210812004325_add_voting_token_to_members.rb
+++ b/db/migrate/20210812004325_add_voting_token_to_members.rb
@@ -1,0 +1,11 @@
+class AddVotingTokenToMembers < ActiveRecord::Migration[5.2]
+  def up
+    add_column :members, :voting_token, :string, unique: true
+    Member.find_each { |member| member.regenerate_voting_token }
+    change_column_null :members, :voting_token, false
+  end
+
+  def down
+    remove_column :members, :voting_token
+  end
+end

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -1,6 +1,4 @@
-require "rails_helper"
-
-describe Admin::MembersController do
+RSpec.describe Admin::MembersController do
   context "when user is authenticated" do
     before do
       @request.env["HTTP_AUTHORIZATION"] = "Basic " + Base64::encode64("secretary:password")

--- a/spec/features/admin/member_spec.rb
+++ b/spec/features/admin/member_spec.rb
@@ -1,6 +1,4 @@
-require "rails_helper"
-
-describe "Admin" do
+RSpec.describe "Admin" do
   context "when user is not authenticated" do
     it "does not see anything" do
       visit "/admin/members"

--- a/spec/features/member_spec.rb
+++ b/spec/features/member_spec.rb
@@ -1,6 +1,4 @@
-require "rails_helper"
-
-describe "Member" do
+RSpec.describe "Member" do
   it "registers for a membership" do
     visit "/"
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,6 +1,4 @@
-require "rails_helper"
-
-describe Member do
+RSpec.describe Member do
   subject { Member.new(full_name: "Jonh Doe") }
 
   it "is valid" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -79,7 +79,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -92,5 +92,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,2 @@
+require 'capybara/rails'
+require 'capybara/email/rspec'

--- a/spec/system/voting_spec.rb
+++ b/spec/system/voting_spec.rb
@@ -1,0 +1,19 @@
+RSpec.feature 'Voting' do
+  scenario 'Member requests vote' do
+    member = Member.create!(
+      full_name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      address: 'Marylebone'
+    )
+
+    visit '/'
+    click_on 'Cast your vote'
+    fill_in 'Email', with: 'ada@example.com'
+    click_on 'Send voting link'
+    expect(page).to have_content('Thanks!')
+
+    open_email 'ada@example.com'
+    expect(current_email).to have_content('Your unique voting link')
+    expect(current_email).to have_content(member.voting_token)
+  end
+end


### PR DESCRIPTION
This adds support for sending out individual voting links in emails.

Voting can be enabled by setting a `VOTE_URL_TEMPLATE` environment variable.

    VOTE_URL_TEMPLATE=https://voting-site.com/token=%token%

When set, a message will appear on the home page, and members will be able to get a unique link emailed to them through a form, which substitutes `%token%` in the URL template with each member's unique `voting_token`.

I apologise in advance – this is a bit of a rush job and I had a messy rebase, thanks to my fork being out of date.
