### PR TITLE
Use security@ruby.nz alias to receive report

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a Vulnerability
 
-If you have found a vulnerability that is exploitable on the live application, please report it privately to one of the moderators on the Ruby NZ Slack, or email secretary@ruby.nz. It may take several days to get a response.
+If you have found a vulnerability that is exploitable on the live application, please report it privately to one of the moderators on the Ruby NZ Slack, or email security@ruby.nz. It may take several days to get a response.
 
 Please explain the severity of the issue and – if you have a fix – please hold off on opening a PR until we can be ready to merge and deploy it quickly.


### PR DESCRIPTION
Per last meeting's discussion. I've just setup security@ruby.nz alias. It's currently forwarding emails to all contacts in the Committee group. Which are:

* president@ruby.nz
* treasurer@ruby.nz
* secretary@ruby.nz

Shall we add general members' personal emails into that group? (currently there are 5 general members in the committee)