### PR TITLE
Enable members to confirm membership

### DIFF
--- a/app/controllers/membership_confirmations_controller.rb
+++ b/app/controllers/membership_confirmations_controller.rb
@@ -1,0 +1,20 @@
+class MembershipConfirmationsController < ApplicationController
+
+  respond_to :html
+
+  def new
+    @confirm = MembershipConfirmation.new
+  end
+
+  def create
+    @confirm = MembershipConfirmation.new(confirmation_params)
+    @confirm.confirm
+    respond_with @confirm, location: :membership_confirmation
+  end
+
+private
+
+  def confirmation_params
+    params.require(:membership_confirmation).permit(:email)
+  end
+end

--- a/app/forms/base.rb
+++ b/app/forms/base.rb
@@ -1,0 +1,18 @@
+class Base
+  include ActiveModel::Model
+
+  attr_accessor :email
+
+  validates_presence_of :email
+  validate :must_be_valid_email
+
+private
+
+  def must_be_valid_email
+    errors.add(:email, :cannot_be_found) unless member.present?
+  end
+
+  def member
+    @member ||= Member.find_by email: email
+  end
+end

--- a/app/forms/membership_confirmation.rb
+++ b/app/forms/membership_confirmation.rb
@@ -1,0 +1,5 @@
+class MembershipConfirmation < Base
+  def confirm
+    member.confirm!
+  end
+end

--- a/app/forms/membership_inquiry.rb
+++ b/app/forms/membership_inquiry.rb
@@ -1,24 +1,7 @@
-class MembershipInquiry
-  include ActiveModel::Model
-
-  attr_accessor :email
-
-  validates_presence_of :email
-  validate :must_be_valid_email
-
+class MembershipInquiry < Base
   def deliver_email
     return unless valid?
     member.reset_token!
     MembershipMailer.inquiry(member).deliver_now
-  end
-
-private
-
-  def must_be_valid_email
-    errors.add(:email, :cannot_be_found) unless member.present?
-  end
-
-  def member
-    @member ||= Member.find_by email: email
   end
 end

--- a/app/mailers/membership_mailer.rb
+++ b/app/mailers/membership_mailer.rb
@@ -16,4 +16,9 @@ class MembershipMailer < ApplicationMailer
     @vote_url = Rails.configuration.vote_url_template.sub('%token%', @member.voting_token)
     mail to: @member.email
   end
+
+  def confirm(member)
+    @member = member
+    mail to: @member.email
+  end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -16,6 +16,10 @@ class Member < ApplicationRecord
   before_create :set_joined_at
   after_create :reset_token!
 
+  def confirm!
+    update! last_active_at: Time.current
+  end
+
   def reset_token!
     update! token: SecureRandom.hex, token_updated_at: Time.current
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -6,6 +6,7 @@ class Member < ApplicationRecord
     email
     address
     data
+    last_active_at
     created_at
     updated_at
   ]

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -21,7 +21,11 @@ class Member < ApplicationRecord
   end
 
   def reset_token!
-    update! token: SecureRandom.hex, token_updated_at: Time.current
+    update!(
+      token: SecureRandom.hex,
+      token_updated_at: Time.current,
+      last_active_at: Time.current
+    )
   end
 
   def join_date

--- a/app/views/application/home.en.html.erb
+++ b/app/views/application/home.en.html.erb
@@ -31,5 +31,12 @@
       Already a member and need to update your details? Not sure if you're a member?<br>
       <%= link_to 'Check existing membership…', new_membership_inquiry_path %>
     </p>
+
+    <br>
+
+    <p>
+      Want to confirm your continued existing membership to the Ruby New Zealand Society?<br>
+      <%= link_to 'Confirm existing membership…', new_membership_confirmation_path %>
+    </p>
   </div>
 </div>

--- a/app/views/membership_confirmations/_form.html.erb
+++ b/app/views/membership_confirmations/_form.html.erb
@@ -1,0 +1,8 @@
+<p>
+  <%= t '.instructions' %>
+
+  <%= simple_form_for(confirm, url: membership_confirmation_path) do |f| %>
+    <%= f.input :email, placeholder: :translate %>
+    <%= f.button :submit %>
+  <% end %>
+</p>

--- a/app/views/membership_confirmations/new.html.erb
+++ b/app/views/membership_confirmations/new.html.erb
@@ -1,0 +1,5 @@
+<div class="page-header">
+  <h2>Membership Confirmation</h2>
+</div>
+
+<%= render 'membership_confirmations/form', confirm: @confirm %>

--- a/app/views/membership_confirmations/show.html.erb
+++ b/app/views/membership_confirmations/show.html.erb
@@ -1,0 +1,10 @@
+<div class="page-header">
+  <h2>Membership Confirmation</h2>
+</div>
+
+<div class="alert alert-success">
+  <p>
+    <span class="glyphicon glyphicon-ok"></span>
+    <%= flash[:notice] %>
+  </p>
+</div>

--- a/app/views/membership_mailer/confirm.html.erb
+++ b/app/views/membership_mailer/confirm.html.erb
@@ -1,0 +1,33 @@
+<style type="text/css">
+  body { background: #eee; }
+</style>
+<style type="text/css">
+    @media only screen and (max-width: 480px){
+        .bodyContent{font-size:14pt !important;}
+    }
+</style>
+
+<div class="content" style="width: 25em;background: white;margin: 1em auto;padding: 1em;font-size: 12pt;font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, sans-serif;">
+  <div class="page-header">
+    <p>
+      Hi <%= @member.full_name %>,
+    </p>
+    <p>
+      Membership of the Ruby New Zealand Society has grown in recent years, and we (the current Ruby New Zealand Committee) want to ensure that we have an accurate list of current members.
+    </p>
+    <p>
+      If you would like to remain a member of Ruby New Zealand, please confirm your existing membership here:
+      <%= link_to 'Confirm Membership', new_membership_confirmation_url %>
+    </p>
+    <p>
+      Being a member of Ruby New Zealand allows you to have your say about the committee and other society matters at the annual AGM.
+    </p>
+    <p>
+      If you choose not to confirm your membership before the end of the year, we will remove your details from the Ruby New Zealand Member’s register. Should you wish to rejoin, you can register for membership here: <%= link_to 'Official Membership Register', root_url %>
+    </p>
+    <p>
+      Kind regards,
+      The 2021 New Zealand Ruby Committee.
+    </p>
+  </div>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { :host => "http://www.example.com" }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,10 @@ en:
     form:
       instructions:
         You can check and update your membership details via the email address you used for membership.
+  membership_confirmations:
+    form:
+      instructions:
+        Submitting your email address will automatically confirm your continued NZ Ruby Membership.
 
   members:
     token_error:
@@ -38,6 +42,9 @@ en:
     membership_inquiries:
       create:
         notice: "Sent email with membership details. Delivery may take a few minutes."
+    membership_confirmations:
+      create:
+        notice: "Congratulations. You have successfully confirmed your continuing Ruby NZ Membership."
 
   membership_mailer:
     inquiry:
@@ -54,6 +61,8 @@ en:
     placeholders:
       membership_inquiry:
         email: "Email Address"
+      membership_confirmation:
+        email: "Email Address"
 
   helpers:
     submit:
@@ -62,3 +71,5 @@ en:
         update: "Save Changes"
       membership_inquiry:
         create: "Request Access"
+      membership_confirmation:
+        create: "Confirm Membership"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,8 @@ en:
       subject: "Membership Details"
     vote_request:
       subject: "Your voting link"
+    confirm:
+      subject: "Ruby NZ Society Membership"
 
   simple_form:
     hints:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   resources :members, except: :index
   resource :membership_inquiry, only: [:new, :create, :show]
+  resource :membership_confirmation, only: [:new, :create, :show]
   resources :vote_requests, only: [:new, :create]
 
   namespace :admin do

--- a/db/migrate/20220116212309_add_last_active_at_to_members.rb
+++ b/db/migrate/20220116212309_add_last_active_at_to_members.rb
@@ -1,0 +1,5 @@
+class AddLastActiveAtToMembers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :members, :last_active_at, :timestamp, null: true
+  end
+end

--- a/spec/controllers/admin/members_controller_spec.rb
+++ b/spec/controllers/admin/members_controller_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Admin::MembersController do
       it "downloads an empty CSV" do
         get :index, format: :csv
 
-        expect(response.body).to eq %[id,full_name,joined_at,email,address,data,created_at,updated_at
+        expect(response.body).to eq(
+%[id,full_name,joined_at,email,address,data,last_active_at,created_at,updated_at
 ]
+        )
       end
     end
 
@@ -39,7 +41,7 @@ RSpec.describe Admin::MembersController do
       it "includes the first member" do
         get :index, format: :csv
 
-        expect(response.body).to match %[.{8}-.{4}-.{4}-.{4}-.{12},Alice,.*,alice@example.com,Alice Address,{},.*,.*]
+        expect(response.body).to match %[.{8}-.{4}-.{4}-.{4}-.{12},Alice,.*,alice@example.com,Alice Address,{},.*,.*,.*]
       end
 
       it "does not include the token" do
@@ -51,7 +53,7 @@ RSpec.describe Admin::MembersController do
       it "includes the second member" do
         get :index, format: :csv
 
-        expect(response.body).to match %[.{8}-.{4}-.{4}-.{4}-.{12},Beatrice,.*,beatrice@example.com,Beatrice Address,{},.*,.*]
+        expect(response.body).to match %[.{8}-.{4}-.{4}-.{4}-.{12},Beatrice,.*,beatrice@example.com,Beatrice Address,{},.*,.*,.*]
       end
     end
   end

--- a/spec/features/membership_confirmation_spec.rb
+++ b/spec/features/membership_confirmation_spec.rb
@@ -1,0 +1,107 @@
+RSpec.describe "membership confirmation process" do
+  let(:member) {
+    Member.create!(
+      full_name: "John Doe",
+      email: "john.doe@example.com",
+      address: "22 Pollen Street, Grey Lynn, Auckland 1021",
+    )
+  }
+
+  context "via email" do
+    it "allows them to confirm membership" do
+      MembershipMailer.confirm(member).deliver_now
+
+      email = ActionMailer::Base.deliveries.last
+
+      expect(email.to).to include "john.doe@example.com"
+
+      expect(email.body.encoded).to match(
+        %r{
+          (?-x:Hi John Doe).*
+          (?-x:Membership of the Ruby New Zealand Society has grown in recent).*
+          (?-x:years, and we \(the current Ruby New Zealand Committee\) want to).*
+          (?-x:ensure that we have an accurate list of current members.).*
+          (?-x:If you would like to remain a member of Ruby New Zealand).*
+          (?-x:please confirm your existing membership here:).*
+          (?-x:Being a member of Ruby New Zealand allows you to have your say).*
+          (?-x:about the committee and other society matters at the annual AGM).*
+          (?-x:Kind regards.*The 2021 New Zealand Ruby Committee.)
+        }xm
+      )
+
+      url = URI.extract(email.body.encoded).detect do |url|
+        url.match(%r[example.com])
+      end
+
+      visit url.gsub('http://www.example.com', '')
+
+      expect(page).to have_content "Membership Confirmation"
+      expect(page).to have_content(
+        "Submitting your email address will automatically confirm your " +
+        "continued NZ Ruby Membership."
+      )
+
+      fill_in "Email", with: "john.doe@example.com"
+      expect {
+        click_on "Confirm Membership"
+      }.to change {
+        member.reload.last_active_at
+      }
+
+      expect(page).to have_content(
+        "Congratulations. You have successfully confirmed your continuing " +
+        "Ruby NZ Membership."
+      )
+    end
+
+    it "allows them to navigate to the membership register" do
+      MembershipMailer.confirm(member).deliver_now
+
+      email = ActionMailer::Base.deliveries.last
+
+      expect(email.to).to include "john.doe@example.com"
+
+      expect(email.body.encoded).to match(
+        %r{
+          (?-x:.*If you choose not to confirm your membership before the end of).*
+          (?-x:the year, we will remove your details from the Ruby New Zealand).*
+          (?-x:Member’s register. Should you wish to rejoin, you can register).*
+          (?-x:for membership here:).*
+          (?-x:Kind regards.*The 2021 New Zealand Ruby Committee.)
+        }xm
+      )
+
+      url = URI.extract(email.body.encoded).detect do |url|
+        url.match(%r[example.com/$])
+      end
+
+      visit url.gsub('http://www.example.com', '')
+
+      expect(page).to have_content("New Members")
+      expect(page).to have_content(
+        "This is Ruby New Zealand’s official membership register."
+      )
+    end
+  end
+
+  context "via membership register url" do
+    it "allows them to confirm membership" do
+      visit "/"
+
+      click_on "Confirm existing membership…"
+
+      fill_in "Email", with: "john.doe@example.com"
+
+      expect {
+        click_on "Confirm Membership"
+      }.to change {
+        member.reload.last_active_at
+      }
+
+      expect(page).to have_content(
+        "Congratulations. You have successfully confirmed your continuing " +
+        "Ruby NZ Membership."
+      )
+    end
+  end
+end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe Member do
     expect { subject.save }.to change { subject.joined_at }
   end
 
+  it "sets last_active_at" do
+    expect { subject.save }.to change { subject.last_active_at }
+  end
+
   it "sets token" do
     expect { subject.save }.to change { subject.token }
   end
@@ -36,6 +40,24 @@ RSpec.describe Member do
       }.to change {
         subject.last_active_at.year
       }.from(3.years.ago.year).to Date.current.year
+    end
+  end
+
+  describe "#reset_token!" do
+    it "sets last_active_at, token, and token_updated_at" do
+      subject.last_active_at = 3.years.ago
+      subject.token_updated_at = 3.years.ago
+
+      expect {
+        subject.reset_token!
+      }.to change {
+        subject.token
+      }.and change {
+        subject.token_updated_at.year
+      }.from(3.years.ago.year).to(Date.current.year)
+      .and change {
+        subject.last_active_at.year
+      }.from(3.years.ago.year).to(Date.current.year)
     end
   end
 end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -26,4 +26,16 @@ RSpec.describe Member do
     subject.full_name = nil
     expect(subject).to be_valid
   end
+
+  describe "#confirm!" do
+    it "sets the last_active_at value of the record to the current time" do
+      subject.last_active_at = 3.years.ago
+
+      expect {
+        subject.confirm!
+      }.to change {
+        subject.last_active_at.year
+      }.from(3.years.ago.year).to Date.current.year
+    end
+  end
 end


### PR DESCRIPTION
When a society grows in membership and a portion of those members aren't engaging with the society (in terms of attendance at AGMs / voting), we could reach a situation where we fail to reach quorum. 

This PR introduces a simple way to confirm that a member is intending to remain active in the society.

A new column `last_active_at` has been created on the `members` table.

When a member is created, updates their details, registers to vote, or manually confirms their membership, this value will be set to the current date.

* Fixes intermittent failing specs by adding `config.action_mailer.default_url_options` to `config/environments/test.rb`
* Adds Members#last_active_at column
* Adds an email to send to prompt users to confirm their membership
* Adds website functionality for users to confirm their own membership
* Sets the last_active_at value to the current date whenever Member#reset_token! is called to indicate continued membership