### PR TITLE
List capybara only once in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,3 @@ end
 group :development do
   gem "listen"
 end
-
-group :test do
-  gem "capybara"
-end


### PR DESCRIPTION
The capybara gem was listed both in the `group :development, test`
group, and the `group :test` group, causing the following warning
to be raised:

```
Your Gemfile lists the gem capybara (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```