### PR TITLE
Amend membership confirmation letter

### DIFF
--- a/app/forms/membership_confirmation.rb
+++ b/app/forms/membership_confirmation.rb
@@ -1,5 +1,6 @@
 class MembershipConfirmation < Base
   def confirm
+    return unless valid?
     member.confirm!
   end
 end

--- a/app/views/membership_mailer/confirm.html.erb
+++ b/app/views/membership_mailer/confirm.html.erb
@@ -23,7 +23,7 @@
       Being a member of Ruby New Zealand allows you to have your say about the committee and other society matters at the annual AGM.
     </p>
     <p>
-      If you choose not to confirm your membership before the end of the year, we will remove your details from the Ruby New Zealand Member’s register. Should you wish to rejoin, you can register for membership here: <%= link_to 'Official Membership Register', root_url %>
+      If you choose not to confirm your membership before the end of next month, we will remove your details from the Ruby New Zealand Member’s register. Should you wish to rejoin, you can register for membership here: <%= link_to 'Official Membership Register', root_url %>
     </p>
     <p>
       Kind regards,

--- a/app/views/membership_mailer/confirm.html.erb
+++ b/app/views/membership_mailer/confirm.html.erb
@@ -27,7 +27,8 @@
     </p>
     <p>
       Kind regards,
-      The 2021 New Zealand Ruby Committee.
+      <br>
+      The 2021 New Zealand Ruby Committee
     </p>
   </div>
 </div>

--- a/spec/features/membership_confirmation_spec.rb
+++ b/spec/features/membership_confirmation_spec.rb
@@ -104,4 +104,15 @@ RSpec.describe "membership confirmation process" do
       )
     end
   end
+
+  it "errors gracefully when a fake or invalid email is provided" do
+    visit "/membership_confirmation/new"
+
+    fill_in "Email", with: "bob"
+
+    click_on "Confirm Membership"
+
+    expect(page).to have_selector(".has-error")
+    expect(page).to have_content("couldn't be found in our membership register")
+  end
 end

--- a/spec/features/membership_confirmation_spec.rb
+++ b/spec/features/membership_confirmation_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "membership confirmation process" do
       expect(email.body.encoded).to match(
         %r{
           (?-x:.*If you choose not to confirm your membership before the end of).*
-          (?-x:the year, we will remove your details from the Ruby New Zealand).*
+          (?-x:next month, we will remove your details from the Ruby New Zealand).*
           (?-x:Member’s register. Should you wish to rejoin, you can register).*
           (?-x:for membership here:).*
           (?-x:Kind regards.*The 2021 New Zealand Ruby Committee.)

--- a/spec/features/membership_confirmation_spec.rb
+++ b/spec/features/membership_confirmation_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "membership confirmation process" do
           (?-x:next month, we will remove your details from the Ruby New Zealand).*
           (?-x:Member’s register. Should you wish to rejoin, you can register).*
           (?-x:for membership here:).*
-          (?-x:Kind regards.*The 2021 New Zealand Ruby Committee.)
+          (?-x:Kind regards.*The 2021 New Zealand Ruby Committee)
         }xm
       )
 


### PR DESCRIPTION
• Fixes formatting of valediction and signature at end of email template
• Modifies the proposed schedule for removing members from society
• Adds error handling to email field in membership_confirmation form for incorrect email submission