### PR TITLE
Minor wording fixes to the home page

### DIFF
--- a/app/views/application/home.en.html.erb
+++ b/app/views/application/home.en.html.erb
@@ -17,7 +17,7 @@
     <p>
       This is Ruby New Zealand’s official membership register.
       Membership isn’t very fancy, but it does allow you to have your say about the committee
-      and other society matters at the AGM held at Rails Camp each year.
+      and other society matters at the AGM held each year.
       <br>
       <%= link_to 'Register for membership…', new_member_path %>
     </p>


### PR DESCRIPTION
Fixes https://github.com/rubynz/membership-register/issues/85

---

Changing to the simplest version as it is the only certainty. (AGM can even be 100% online if needed, as it was in the past).

But I am happy to replace `Rails Camp` with `Ruby Retreat` if the committee believes is the best 🙏.